### PR TITLE
tweak calendar layout

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,12 +13,10 @@ Based on the [simplified calendar](https://observablehq.com/@observablehq/plot-s
 ```js
 Plot.plot({
   padding: 0,
+  aspectRatio: 1,
   x: {axis: null},
-  y: {
-    tickFormat: Plot.formatWeekday("en", "narrow"),
-    tickSize: 0,
-  },
-  fy: {tickFormat: ""},
+  y: {tickFormat: Plot.formatWeekday("en", "narrow"), tickSize: 0},
+  fy: {tickFormat: "", padding: 0.1},
   color: {scheme: "PiYG", domain: [0, 10]},
   marks: [
     Plot.cell(days, {
@@ -33,14 +31,15 @@ Plot.plot({
         var d = new Date(d.day);
         return `https://simonwillison.net/${d.getFullYear()}/${d.toLocaleString(
           "en-us",
-          { month: "short" }
+          {month: "short"}
         )}/${d.getDate()}/`;
       },
-      target: "_blank",
+      target: "_blank"
     })
   ]
 })
 ```
+
 ```js
-const days = FileAttachment("./data/blog-days.json").json()
+const days = FileAttachment("./data/blog-days.json").json();
 ```


### PR DESCRIPTION
This…

- adds the `aspectRatio: 1` for square calendar cells
- adds `fy: {padding: 0.1}` for a slightly bigger gap between years

<img width="651" alt="Screenshot 2024-02-19 at 8 45 48 PM" src="https://github.com/simonw/blog-heatmap/assets/230541/84aab3a7-deb8-4a1a-a6fd-a72a45d5409b">
